### PR TITLE
Cross-origin resource sharing

### DIFF
--- a/src/server/server.go
+++ b/src/server/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/SevenTV/EventAPI/src/configure"
 	"github.com/SevenTV/EventAPI/src/utils"
 	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/cors"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -35,6 +36,10 @@ func New(ctx context.Context, connType, connURI string) (*fiber.App, <-chan stru
 		}()
 		return c.Next()
 	})
+	app.Use(cors.New(cors.Config{
+		AllowOrigins: "*",
+		AllowMethods: "GET,POST,PUT,PATCH,DELETE",
+	}))
 
 	Health(app, conns)
 	Testing(app)


### PR DESCRIPTION
Cross-origin resource sharing is a mechanism that allows restricted resources on a web page to be requested from another domain outside the domain from which the first resource was served. A web page may freely embed cross-origin images, stylesheets, scripts, iframes, and videos.