### PR TITLE
Fix Event Names

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -81,7 +81,7 @@ interface EmoteEventUpate {
   // The user who caused this event to trigger.
   actor: string; 
   // An emote object. Null if the action is "REMOVE".
-  extra_data?: ExtraEmoteData; 
+  emote?: ExtraEmoteData; 
 }
 
 interface ExtraEmoteData {
@@ -123,7 +123,7 @@ Example JSON
   "name": "WIDEGIGACHAD",
   "action": "ADD",
   "actor": "TroyDota",
-  "extra_data": {
+  "emote": {
     "name": "WIDEGIGACHAD",
     "visibility": 0,
     "mime": "image/webp",
@@ -140,10 +140,3 @@ Example JSON
   }
 }
 ```
-
-1. The `channel` is the channel this event relates to.
-1. The `emote_id` is an ObjectID as hex.
-1. The `emote` is an Emote object.
-1. The `name` is the name of the emote, respecting capitalization.
-1. The `action` is either `"ADD"` or `"REMOVE"` or `"UPDATE"`.
-1. The `actor` is the person who issued the triggered this event. By either adding, removing or aliasing an emote.

--- a/README.MD
+++ b/README.MD
@@ -29,12 +29,12 @@ You can request to listen up 100 channels per connection.
 ```js
 const source = new EventSource('https://events.7tv.app/v1/channel-emotes?channel=troydota&channel=anatoleam');
 
-source.addEventListener("connected", (e) => {
+source.addEventListener("ready", (e) => {
   // Should be "7tv-event-sub.v1" since this is the `v1` endpoint
   console.log(e.data); 
 }, false);
 
-source.addEventListener("message", (e) => {
+source.addEventListener("update", (e) => {
   // This is a JSON payload matching the type for the specified event channel
   console.log(e.data);
 }, false);
@@ -42,10 +42,6 @@ source.addEventListener("message", (e) => {
 source.addEventListener("open", (e) => {
   // Connection was opened.
 }, false);
-
-source.addEventListener("ready", (e) => {
-  // Connection is ready to receive events
-})
 
 source.addEventListener("error", (e) => {
   if (e.readyState === EventSource.CLOSED) {
@@ -74,12 +70,74 @@ The `X-Active-Connections` header will be set with the current number of active 
 
 ```ts
 interface EmoteEventUpate {
-  channel: string; // The channel this update affects
-  emote_id: string; // The ID of the emote
-  emote?: Emote; // An emote object. Null if the action is "REMOVE"
-  name: string; // The name of the emote
-  action: "ADD" | "REMOVE" | "UPDATE"; // The action done
-  actor: string; // The user who caused this
+  // The channel this update affects.
+  channel: string; 
+  // The ID of the emote.
+  emote_id: string; 
+  // The name or channel alias of the emote.
+  name: string; 
+  // The action done.
+  action: "ADD" | "REMOVE" | "UPDATE"; 
+  // The user who caused this event to trigger.
+  actor: string; 
+  // An emote object. Null if the action is "REMOVE".
+  extra_data?: ExtraEmoteData; 
+}
+
+interface ExtraEmoteData {
+  // Original name of the emote.
+  name: string;
+  // The visibility bitfield of this emote.
+  visibility: number;
+  // The MIME type of the images.
+  mime: string;
+  // The TAGs on this emote.
+  tags: string[];
+  // The widths of the images.
+  width: [number, number, number, number];
+  // The heights of the images.
+  height: [number, number, number, number];
+  // The animation status of the emote.
+  animated: boolean;
+  // Infomation about the uploader.
+  owner: {
+    // 7TV ID of the owner.
+    id: string;
+    // Twitch ID of the owner.
+    twitch_id: string;
+    // Twitch DisplayName of the owner.
+    display_name: string;
+    // Twitch Login of the owner. 
+    login: string;
+  }
+}
+
+```
+
+Example JSON
+
+```json
+{
+  "channel": "troydota",
+  "emote_id": "60bf2b5b74461cf8fe2d187f",
+  "name": "WIDEGIGACHAD",
+  "action": "ADD",
+  "actor": "TroyDota",
+  "extra_data": {
+    "name": "WIDEGIGACHAD",
+    "visibility": 0,
+    "mime": "image/webp",
+    "tags": [],
+    "width": [384, 228, 144, 96],
+    "height": [128, 76, 48, 32],
+    "animated": true,
+    "owner": {
+      "id": "60af9846ebfcf7562edb10a3",
+      "display_name": "noodlemanhours",
+      "twitch_id": "84181465",
+      "login": "noodlemanhours"
+    },
+  }
 }
 ```
 

--- a/README.MD
+++ b/README.MD
@@ -72,18 +72,20 @@ The `X-Active-Connections` header will be set with the current number of active 
 
 #### EmoteEventUpdate
 
-```json
-{
-	"channel": string,
-	"emote_id": string,
-	"name": string,
-	"action": "removed" or "added" or "renamed",
-	"author": string
+```ts
+interface EmoteEventUpate {
+  channel: string; // The channel this update affects
+  emote_id: string; // The ID of the emote
+  emote?: Emote; // An emote object. Null if the action is "REMOVE"
+  name: string; // The name of the emote
+  action: "ADD" | "REMOVE" | "UPDATE"; // The action done
+  actor: string; // The user who caused this
 }
 ```
 
 1. The `channel` is the channel this event relates to.
-2. The `emote_id` is an ObjectID as hex.
-3. The `name` is the name of the emote, respecting capitalization.
-4. The `action` is either `"removed"` or `"added"` or `"renamed"`.
-5. The `author` is the person who issued the triggered this event. By either adding, removing or aliasing an emote.
+1. The `emote_id` is an ObjectID as hex.
+1. The `emote` is an Emote object.
+1. The `name` is the name of the emote, respecting capitalization.
+1. The `action` is either `"ADD"` or `"REMOVE"` or `"UPDATE"`.
+1. The `actor` is the person who issued the triggered this event. By either adding, removing or aliasing an emote.

--- a/README.MD
+++ b/README.MD
@@ -34,14 +34,18 @@ source.addEventListener("connected", (e) => {
   console.log(e.data); 
 }, false);
 
-source.addEventListener("update", (e) => {
-  // This is a JSON payload of the type `EmoteEventUpdate`
+source.addEventListener("message", (e) => {
+  // This is a JSON payload matching the type for the specified event channel
   console.log(e.data);
 }, false);
 
 source.addEventListener("open", (e) => {
   // Connection was opened.
 }, false);
+
+source.addEventListener("listening", (e) => {
+  // Connection is ready to receive events
+})
 
 source.addEventListener("error", (e) => {
   if (e.readyState === EventSource.CLOSED) {

--- a/README.MD
+++ b/README.MD
@@ -43,7 +43,7 @@ source.addEventListener("open", (e) => {
   // Connection was opened.
 }, false);
 
-source.addEventListener("listening", (e) => {
+source.addEventListener("ready", (e) => {
   // Connection is ready to receive events
 })
 

--- a/src/redis/redis_test.go
+++ b/src/redis/redis_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func InitRedis(t *testing.T) *miniredis.Miniredis {
+	defer time.Sleep(time.Second)
 	if val, ok := os.LookupEnv("USE_LOCAL_REDIS"); ok && val == "1" {
 		Init("redis://127.0.0.1:6379/0")
 		return nil

--- a/src/server/events-v1.go
+++ b/src/server/events-v1.go
@@ -81,7 +81,7 @@ func EventsV1(app fiber.Router) {
 				msg string
 				err error
 			)
-			if _, err = w.WriteString("event: connected\ndata: 7tv-event-sub.v1\n\n"); err != nil {
+			if _, err = w.WriteString("event: open\ndata: 7tv-event-sub.v1\n\n"); err != nil {
 				return
 			}
 			if err = w.Flush(); err != nil {

--- a/src/server/events-v1.go
+++ b/src/server/events-v1.go
@@ -81,7 +81,7 @@ func EventsV1(app fiber.Router) {
 				msg string
 				err error
 			)
-			if _, err = w.WriteString("event: open\ndata: 7tv-event-sub.v1\n\n"); err != nil {
+			if _, err = w.WriteString("event: listening\ndata: 7tv-event-sub.v1\n\n"); err != nil {
 				return
 			}
 			if err = w.Flush(); err != nil {

--- a/src/server/events-v1.go
+++ b/src/server/events-v1.go
@@ -81,7 +81,7 @@ func EventsV1(app fiber.Router) {
 				msg string
 				err error
 			)
-			if _, err = w.WriteString("event: listening\ndata: 7tv-event-sub.v1\n\n"); err != nil {
+			if _, err = w.WriteString("event: ready\ndata: 7tv-event-sub.v1\n\n"); err != nil {
 				return
 			}
 			if err = w.Flush(); err != nil {

--- a/src/server/events-v1.go
+++ b/src/server/events-v1.go
@@ -102,7 +102,7 @@ func EventsV1(app fiber.Router) {
 						return
 					}
 				case msg = <-subCh:
-					if _, err = w.WriteString("event: message\n"); err != nil {
+					if _, err = w.WriteString("event: update\n"); err != nil {
 						return
 					}
 					if _, err = w.WriteString("data: "); err != nil {

--- a/src/server/events-v1.go
+++ b/src/server/events-v1.go
@@ -102,7 +102,7 @@ func EventsV1(app fiber.Router) {
 						return
 					}
 				case msg = <-subCh:
-					if _, err = w.WriteString("event: update\n"); err != nil {
+					if _, err = w.WriteString("event: message\n"); err != nil {
 						return
 					}
 					if _, err = w.WriteString("data: "); err != nil {

--- a/src/server/server_test.go
+++ b/src/server/server_test.go
@@ -106,7 +106,7 @@ func Test_EventsSingleChannel(t *testing.T) {
 	testData := `{"channel":"troydota","emote_id":"123","name":"emote-name","action":"added","author":"troydota"}`
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:troydota", testData)
 
-	Assert(t, readMessage(), fmt.Sprintf("event: message\ndata: %s", testData), "data error")
+	Assert(t, readMessage(), fmt.Sprintf("event: update\ndata: %s", testData), "data error")
 
 	Assert(t, resp.Body.Close(), nil, "close body error")
 
@@ -160,9 +160,9 @@ func Test_EventsMultiChannels(t *testing.T) {
 
 	testData := `{"channel":"troydota","emote_id":"123","name":"emote-name","action":"added","author":"troydota"}`
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:troydota", testData)
-	Assert(t, readMessage(), fmt.Sprintf("event: message\ndata: %s", testData), "data error")
+	Assert(t, readMessage(), fmt.Sprintf("event: update\ndata: %s", testData), "data error")
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:anatoleam", testData)
-	Assert(t, readMessage(), fmt.Sprintf("event: message\ndata: %s", testData), "data error")
+	Assert(t, readMessage(), fmt.Sprintf("event: update\ndata: %s", testData), "data error")
 
 	Assert(t, resp.Body.Close(), nil, "close body error")
 
@@ -216,9 +216,9 @@ func Test_EventsMultiChannelComma(t *testing.T) {
 
 	testData := `{"channel":"troydota","emote_id":"123","name":"emote-name","action":"added","author":"troydota"}`
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:troydota", testData)
-	Assert(t, readMessage(), fmt.Sprintf("event: message\ndata: %s", testData), "data error")
+	Assert(t, readMessage(), fmt.Sprintf("event: update\ndata: %s", testData), "data error")
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:anatoleam", testData)
-	Assert(t, readMessage(), fmt.Sprintf("event: message\ndata: %s", testData), "data error")
+	Assert(t, readMessage(), fmt.Sprintf("event: update\ndata: %s", testData), "data error")
 
 	Assert(t, resp.Body.Close(), nil, "close body error")
 
@@ -272,9 +272,9 @@ func Test_EventsMultiChannelPlus(t *testing.T) {
 
 	testData := `{"channel":"troydota","emote_id":"123","name":"emote-name","action":"added","author":"troydota"}`
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:troydota", testData)
-	Assert(t, readMessage(), fmt.Sprintf("event: message\ndata: %s", testData), "data error")
+	Assert(t, readMessage(), fmt.Sprintf("event: update\ndata: %s", testData), "data error")
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:anatoleam", testData)
-	Assert(t, readMessage(), fmt.Sprintf("event: message\ndata: %s", testData), "data error")
+	Assert(t, readMessage(), fmt.Sprintf("event: update\ndata: %s", testData), "data error")
 
 	Assert(t, resp.Body.Close(), nil, "close body error")
 
@@ -328,9 +328,9 @@ func Test_EventsMultiChannelSpace(t *testing.T) {
 
 	testData := `{"channel":"troydota","emote_id":"123","name":"emote-name","action":"added","author":"troydota"}`
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:troydota", testData)
-	Assert(t, readMessage(), fmt.Sprintf("event: message\ndata: %s", testData), "data error")
+	Assert(t, readMessage(), fmt.Sprintf("event: update\ndata: %s", testData), "data error")
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:anatoleam", testData)
-	Assert(t, readMessage(), fmt.Sprintf("event: message\ndata: %s", testData), "data error")
+	Assert(t, readMessage(), fmt.Sprintf("event: update\ndata: %s", testData), "data error")
 
 	Assert(t, resp.Body.Close(), nil, "close body error")
 

--- a/src/server/server_test.go
+++ b/src/server/server_test.go
@@ -110,7 +110,7 @@ func Test_EventsSingleChannel(t *testing.T) {
   "name": "WIDEGIGACHAD",
   "action": "ADD",
   "actor": "TroyDota",
-  "extra_data": {
+  "emote": {
     "name": "WIDEGIGACHAD",
     "visibility": 0,
     "mime": "image/webp",
@@ -186,7 +186,7 @@ func Test_EventsMultiChannels(t *testing.T) {
   "name": "WIDEGIGACHAD",
   "action": "ADD",
   "actor": "TroyDota",
-  "extra_data": {
+  "emote": {
     "name": "WIDEGIGACHAD",
     "visibility": 0,
     "mime": "image/webp",
@@ -210,7 +210,7 @@ func Test_EventsMultiChannels(t *testing.T) {
   "name": "WIDEGIGACHAD",
   "action": "ADD",
   "actor": "TroyDota",
-  "extra_data": {
+  "emote": {
     "name": "WIDEGIGACHAD",
     "visibility": 0,
     "mime": "image/webp",

--- a/src/server/server_test.go
+++ b/src/server/server_test.go
@@ -101,7 +101,7 @@ func Test_EventsSingleChannel(t *testing.T) {
 	}
 
 	Assert(t, err, nil, "header error")
-	Assert(t, readMessage(), "event: open\ndata: 7tv-event-sub.v1", "header value")
+	Assert(t, readMessage(), "event: listening\ndata: 7tv-event-sub.v1", "header value")
 
 	testData := `{"channel":"troydota","emote_id":"123","name":"emote-name","action":"added","author":"troydota"}`
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:troydota", testData)
@@ -156,7 +156,7 @@ func Test_EventsMultiChannels(t *testing.T) {
 	}
 
 	Assert(t, err, nil, "header error")
-	Assert(t, readMessage(), "event: open\ndata: 7tv-event-sub.v1", "header value")
+	Assert(t, readMessage(), "event: listening\ndata: 7tv-event-sub.v1", "header value")
 
 	testData := `{"channel":"troydota","emote_id":"123","name":"emote-name","action":"added","author":"troydota"}`
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:troydota", testData)
@@ -212,7 +212,7 @@ func Test_EventsMultiChannelComma(t *testing.T) {
 	}
 
 	Assert(t, err, nil, "header error")
-	Assert(t, readMessage(), "event: open\ndata: 7tv-event-sub.v1", "header value")
+	Assert(t, readMessage(), "event: listening\ndata: 7tv-event-sub.v1", "header value")
 
 	testData := `{"channel":"troydota","emote_id":"123","name":"emote-name","action":"added","author":"troydota"}`
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:troydota", testData)
@@ -268,7 +268,7 @@ func Test_EventsMultiChannelPlus(t *testing.T) {
 	}
 
 	Assert(t, err, nil, "header error")
-	Assert(t, readMessage(), "event: open\ndata: 7tv-event-sub.v1", "header value")
+	Assert(t, readMessage(), "event: listening\ndata: 7tv-event-sub.v1", "header value")
 
 	testData := `{"channel":"troydota","emote_id":"123","name":"emote-name","action":"added","author":"troydota"}`
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:troydota", testData)
@@ -324,7 +324,7 @@ func Test_EventsMultiChannelSpace(t *testing.T) {
 	}
 
 	Assert(t, err, nil, "header error")
-	Assert(t, readMessage(), "event: open\ndata: 7tv-event-sub.v1", "header value")
+	Assert(t, readMessage(), "event: listening\ndata: 7tv-event-sub.v1", "header value")
 
 	testData := `{"channel":"troydota","emote_id":"123","name":"emote-name","action":"added","author":"troydota"}`
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:troydota", testData)

--- a/src/server/server_test.go
+++ b/src/server/server_test.go
@@ -101,12 +101,12 @@ func Test_EventsSingleChannel(t *testing.T) {
 	}
 
 	Assert(t, err, nil, "header error")
-	Assert(t, readMessage(), "event: connected\ndata: 7tv-event-sub.v1", "header value")
+	Assert(t, readMessage(), "event: open\ndata: 7tv-event-sub.v1", "header value")
 
 	testData := `{"channel":"troydota","emote_id":"123","name":"emote-name","action":"added","author":"troydota"}`
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:troydota", testData)
 
-	Assert(t, readMessage(), fmt.Sprintf("event: update\ndata: %s", testData), "data error")
+	Assert(t, readMessage(), fmt.Sprintf("event: message\ndata: %s", testData), "data error")
 
 	Assert(t, resp.Body.Close(), nil, "close body error")
 
@@ -156,13 +156,13 @@ func Test_EventsMultiChannels(t *testing.T) {
 	}
 
 	Assert(t, err, nil, "header error")
-	Assert(t, readMessage(), "event: connected\ndata: 7tv-event-sub.v1", "header value")
+	Assert(t, readMessage(), "event: open\ndata: 7tv-event-sub.v1", "header value")
 
 	testData := `{"channel":"troydota","emote_id":"123","name":"emote-name","action":"added","author":"troydota"}`
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:troydota", testData)
-	Assert(t, readMessage(), fmt.Sprintf("event: update\ndata: %s", testData), "data error")
+	Assert(t, readMessage(), fmt.Sprintf("event: message\ndata: %s", testData), "data error")
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:anatoleam", testData)
-	Assert(t, readMessage(), fmt.Sprintf("event: update\ndata: %s", testData), "data error")
+	Assert(t, readMessage(), fmt.Sprintf("event: message\ndata: %s", testData), "data error")
 
 	Assert(t, resp.Body.Close(), nil, "close body error")
 
@@ -212,13 +212,13 @@ func Test_EventsMultiChannelComma(t *testing.T) {
 	}
 
 	Assert(t, err, nil, "header error")
-	Assert(t, readMessage(), "event: connected\ndata: 7tv-event-sub.v1", "header value")
+	Assert(t, readMessage(), "event: open\ndata: 7tv-event-sub.v1", "header value")
 
 	testData := `{"channel":"troydota","emote_id":"123","name":"emote-name","action":"added","author":"troydota"}`
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:troydota", testData)
-	Assert(t, readMessage(), fmt.Sprintf("event: update\ndata: %s", testData), "data error")
+	Assert(t, readMessage(), fmt.Sprintf("event: message\ndata: %s", testData), "data error")
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:anatoleam", testData)
-	Assert(t, readMessage(), fmt.Sprintf("event: update\ndata: %s", testData), "data error")
+	Assert(t, readMessage(), fmt.Sprintf("event: message\ndata: %s", testData), "data error")
 
 	Assert(t, resp.Body.Close(), nil, "close body error")
 
@@ -268,13 +268,13 @@ func Test_EventsMultiChannelPlus(t *testing.T) {
 	}
 
 	Assert(t, err, nil, "header error")
-	Assert(t, readMessage(), "event: connected\ndata: 7tv-event-sub.v1", "header value")
+	Assert(t, readMessage(), "event: open\ndata: 7tv-event-sub.v1", "header value")
 
 	testData := `{"channel":"troydota","emote_id":"123","name":"emote-name","action":"added","author":"troydota"}`
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:troydota", testData)
-	Assert(t, readMessage(), fmt.Sprintf("event: update\ndata: %s", testData), "data error")
+	Assert(t, readMessage(), fmt.Sprintf("event: message\ndata: %s", testData), "data error")
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:anatoleam", testData)
-	Assert(t, readMessage(), fmt.Sprintf("event: update\ndata: %s", testData), "data error")
+	Assert(t, readMessage(), fmt.Sprintf("event: message\ndata: %s", testData), "data error")
 
 	Assert(t, resp.Body.Close(), nil, "close body error")
 
@@ -324,13 +324,13 @@ func Test_EventsMultiChannelSpace(t *testing.T) {
 	}
 
 	Assert(t, err, nil, "header error")
-	Assert(t, readMessage(), "event: connected\ndata: 7tv-event-sub.v1", "header value")
+	Assert(t, readMessage(), "event: open\ndata: 7tv-event-sub.v1", "header value")
 
 	testData := `{"channel":"troydota","emote_id":"123","name":"emote-name","action":"added","author":"troydota"}`
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:troydota", testData)
-	Assert(t, readMessage(), fmt.Sprintf("event: update\ndata: %s", testData), "data error")
+	Assert(t, readMessage(), fmt.Sprintf("event: message\ndata: %s", testData), "data error")
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:anatoleam", testData)
-	Assert(t, readMessage(), fmt.Sprintf("event: update\ndata: %s", testData), "data error")
+	Assert(t, readMessage(), fmt.Sprintf("event: message\ndata: %s", testData), "data error")
 
 	Assert(t, resp.Body.Close(), nil, "close body error")
 

--- a/src/server/server_test.go
+++ b/src/server/server_test.go
@@ -101,7 +101,7 @@ func Test_EventsSingleChannel(t *testing.T) {
 	}
 
 	Assert(t, err, nil, "header error")
-	Assert(t, readMessage(), "event: listening\ndata: 7tv-event-sub.v1", "header value")
+	Assert(t, readMessage(), "event: ready\ndata: 7tv-event-sub.v1", "header value")
 
 	testData := `{"channel":"troydota","emote_id":"123","name":"emote-name","action":"added","author":"troydota"}`
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:troydota", testData)
@@ -156,7 +156,7 @@ func Test_EventsMultiChannels(t *testing.T) {
 	}
 
 	Assert(t, err, nil, "header error")
-	Assert(t, readMessage(), "event: listening\ndata: 7tv-event-sub.v1", "header value")
+	Assert(t, readMessage(), "event: ready\ndata: 7tv-event-sub.v1", "header value")
 
 	testData := `{"channel":"troydota","emote_id":"123","name":"emote-name","action":"added","author":"troydota"}`
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:troydota", testData)
@@ -212,7 +212,7 @@ func Test_EventsMultiChannelComma(t *testing.T) {
 	}
 
 	Assert(t, err, nil, "header error")
-	Assert(t, readMessage(), "event: listening\ndata: 7tv-event-sub.v1", "header value")
+	Assert(t, readMessage(), "event: ready\ndata: 7tv-event-sub.v1", "header value")
 
 	testData := `{"channel":"troydota","emote_id":"123","name":"emote-name","action":"added","author":"troydota"}`
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:troydota", testData)
@@ -268,7 +268,7 @@ func Test_EventsMultiChannelPlus(t *testing.T) {
 	}
 
 	Assert(t, err, nil, "header error")
-	Assert(t, readMessage(), "event: listening\ndata: 7tv-event-sub.v1", "header value")
+	Assert(t, readMessage(), "event: ready\ndata: 7tv-event-sub.v1", "header value")
 
 	testData := `{"channel":"troydota","emote_id":"123","name":"emote-name","action":"added","author":"troydota"}`
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:troydota", testData)
@@ -324,7 +324,7 @@ func Test_EventsMultiChannelSpace(t *testing.T) {
 	}
 
 	Assert(t, err, nil, "header error")
-	Assert(t, readMessage(), "event: listening\ndata: 7tv-event-sub.v1", "header value")
+	Assert(t, readMessage(), "event: ready\ndata: 7tv-event-sub.v1", "header value")
 
 	testData := `{"channel":"troydota","emote_id":"123","name":"emote-name","action":"added","author":"troydota"}`
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:troydota", testData)

--- a/src/server/server_test.go
+++ b/src/server/server_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func InitRedis(t *testing.T) *miniredis.Miniredis {
+	defer time.Sleep(time.Second)
 	if val, ok := os.LookupEnv("USE_LOCAL_REDIS"); ok && val == "1" {
 		redis.Init("redis://127.0.0.1:6379/0")
 		return nil
@@ -103,7 +104,28 @@ func Test_EventsSingleChannel(t *testing.T) {
 	Assert(t, err, nil, "header error")
 	Assert(t, readMessage(), "event: ready\ndata: 7tv-event-sub.v1", "header value")
 
-	testData := `{"channel":"troydota","emote_id":"123","name":"emote-name","action":"added","author":"troydota"}`
+	testData := `{
+  "channel": "troydota",
+  "emote_id": "60bf2b5b74461cf8fe2d187f",
+  "name": "WIDEGIGACHAD",
+  "action": "ADD",
+  "actor": "TroyDota",
+  "extra_data": {
+    "name": "WIDEGIGACHAD",
+    "visibility": 0,
+    "mime": "image/webp",
+    "tags": [],
+    "width": [384, 228, 144, 96],
+    "height": [128, 76, 48, 32],
+    "animated": true,
+    "owner": {
+      "id": "60af9846ebfcf7562edb10a3",
+      "display_name": "noodlemanhours",
+      "twitch_id": "84181465",
+      "login": "noodlemanhours"
+    },
+  }
+}`
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:troydota", testData)
 
 	Assert(t, readMessage(), fmt.Sprintf("event: update\ndata: %s", testData), "data error")
@@ -158,9 +180,52 @@ func Test_EventsMultiChannels(t *testing.T) {
 	Assert(t, err, nil, "header error")
 	Assert(t, readMessage(), "event: ready\ndata: 7tv-event-sub.v1", "header value")
 
-	testData := `{"channel":"troydota","emote_id":"123","name":"emote-name","action":"added","author":"troydota"}`
+	testData := `{
+  "channel": "troydota",
+  "emote_id": "60bf2b5b74461cf8fe2d187f",
+  "name": "WIDEGIGACHAD",
+  "action": "ADD",
+  "actor": "TroyDota",
+  "extra_data": {
+    "name": "WIDEGIGACHAD",
+    "visibility": 0,
+    "mime": "image/webp",
+    "tags": [],
+    "width": [384, 228, 144, 96],
+    "height": [128, 76, 48, 32],
+    "animated": true,
+    "owner": {
+      "id": "60af9846ebfcf7562edb10a3",
+      "display_name": "noodlemanhours",
+      "twitch_id": "84181465",
+      "login": "noodlemanhours"
+    },
+  }
+}`
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:troydota", testData)
 	Assert(t, readMessage(), fmt.Sprintf("event: update\ndata: %s", testData), "data error")
+	testData = `{
+  "channel": "anatoleam",
+  "emote_id": "60bf2b5b74461cf8fe2d187f",
+  "name": "WIDEGIGACHAD",
+  "action": "ADD",
+  "actor": "TroyDota",
+  "extra_data": {
+    "name": "WIDEGIGACHAD",
+    "visibility": 0,
+    "mime": "image/webp",
+    "tags": [],
+    "width": [384, 228, 144, 96],
+    "height": [128, 76, 48, 32],
+    "animated": true,
+    "owner": {
+      "id": "60af9846ebfcf7562edb10a3",
+      "display_name": "noodlemanhours",
+      "twitch_id": "84181465",
+      "login": "noodlemanhours"
+    },
+  }
+}`
 	redis.Client.Publish(ctx, "events-v1:channel-emotes:anatoleam", testData)
 	Assert(t, readMessage(), fmt.Sprintf("event: update\ndata: %s", testData), "data error")
 


### PR DESCRIPTION
The default listeners outlined in the [`EventSource`](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) Web API are `open` and `message`. This changes the "update" event to "message". "connected" was also changed to "listening", as it sounds redundant with the default-fired `open` event, whereas `listening` indicates the connection is fully ready to receive events.