### PR TITLE
Fixed typo in docs

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -69,7 +69,7 @@ The `X-Active-Connections` header will be set with the current number of active 
 #### EmoteEventUpdate
 
 ```ts
-interface EmoteEventUpate {
+interface EmoteEventUpdate {
   // The channel this update affects.
   channel: string; 
   // The ID of the emote.


### PR DESCRIPTION
found this while cv pasting the interface ![forsenCD](https://cdn.frankerfacez.com/emote/249060/1)