### PR TITLE
Dispatch Effects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/json-iterator/go v1.1.12
 	github.com/prometheus/client_golang v1.14.0
-	github.com/seventv/api v0.0.0-20230107174207-b94bf6b52c5d
-	github.com/seventv/common v0.0.0-20221228160040-bcf96a9f11bd
+	github.com/seventv/api v0.0.0-20230107230459-d5a8f65168f8
+	github.com/seventv/common v0.0.0-20230107175235-62dbd2e54c8e
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.14.0
 	github.com/valyala/fasthttp v1.43.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/json-iterator/go v1.1.12
 	github.com/prometheus/client_golang v1.14.0
-	github.com/seventv/api v0.0.0-20221228213352-e8c585947fd8
+	github.com/seventv/api v0.0.0-20230107174207-b94bf6b52c5d
 	github.com/seventv/common v0.0.0-20221228160040-bcf96a9f11bd
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,8 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/savsgio/gotils v0.0.0-20211223103454-d0aaa54c5899/go.mod h1:oejLrk1Y/5zOF+c/aHtXqn3TFlzzbAgPWg8zBiAHDas=
 github.com/savsgio/gotils v0.0.0-20220530130905-52f3993e8d6d h1:Q+gqLBOPkFGHyCJxXMRqtUgUbTjI8/Ze8vu8GGyNFwo=
 github.com/savsgio/gotils v0.0.0-20220530130905-52f3993e8d6d/go.mod h1:Gy+0tqhJvgGlqnTF8CVGP0AaGRjwBtXs/a5PA0Y3+A4=
-github.com/seventv/api v0.0.0-20221228213352-e8c585947fd8 h1:6nieC6tBhp5bRbZ1e8IPzWnD04qjPqD8EfPiF3wDKCk=
-github.com/seventv/api v0.0.0-20221228213352-e8c585947fd8/go.mod h1:otOBLMEpMKZiW8RkHQKZfsHFcindCvyADv2SuyvC44M=
+github.com/seventv/api v0.0.0-20230107174207-b94bf6b52c5d h1:cUZYN6cjBIJdKBcN2MGDQ2g2ESYPTcaqNaRbcPDrV3c=
+github.com/seventv/api v0.0.0-20230107174207-b94bf6b52c5d/go.mod h1:otOBLMEpMKZiW8RkHQKZfsHFcindCvyADv2SuyvC44M=
 github.com/seventv/common v0.0.0-20221228160040-bcf96a9f11bd h1:jEKpDg1QxcLPUDYXVmXKH/jtTSDAHhpcRVxrJ9wJWL4=
 github.com/seventv/common v0.0.0-20221228160040-bcf96a9f11bd/go.mod h1:jHHFe3uNMyzb/ReDqMvaI/A1euvV/PW/G+2PhcWQqWw=
 github.com/spf13/afero v1.9.3 h1:41FoI0fD7OR7mGcKE/aOiLkGreyf8ifIOQmJANWogMk=

--- a/go.sum
+++ b/go.sum
@@ -243,10 +243,10 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/savsgio/gotils v0.0.0-20211223103454-d0aaa54c5899/go.mod h1:oejLrk1Y/5zOF+c/aHtXqn3TFlzzbAgPWg8zBiAHDas=
 github.com/savsgio/gotils v0.0.0-20220530130905-52f3993e8d6d h1:Q+gqLBOPkFGHyCJxXMRqtUgUbTjI8/Ze8vu8GGyNFwo=
 github.com/savsgio/gotils v0.0.0-20220530130905-52f3993e8d6d/go.mod h1:Gy+0tqhJvgGlqnTF8CVGP0AaGRjwBtXs/a5PA0Y3+A4=
-github.com/seventv/api v0.0.0-20230107174207-b94bf6b52c5d h1:cUZYN6cjBIJdKBcN2MGDQ2g2ESYPTcaqNaRbcPDrV3c=
-github.com/seventv/api v0.0.0-20230107174207-b94bf6b52c5d/go.mod h1:otOBLMEpMKZiW8RkHQKZfsHFcindCvyADv2SuyvC44M=
-github.com/seventv/common v0.0.0-20221228160040-bcf96a9f11bd h1:jEKpDg1QxcLPUDYXVmXKH/jtTSDAHhpcRVxrJ9wJWL4=
-github.com/seventv/common v0.0.0-20221228160040-bcf96a9f11bd/go.mod h1:jHHFe3uNMyzb/ReDqMvaI/A1euvV/PW/G+2PhcWQqWw=
+github.com/seventv/api v0.0.0-20230107230459-d5a8f65168f8 h1:Uo6IPOdeDpajXvxQQDj+PSptfbRewVthNVuDN0wbS44=
+github.com/seventv/api v0.0.0-20230107230459-d5a8f65168f8/go.mod h1:wea5Q2G9K6JNV6jI16NLFrajR3QFqxMgvIyD7A3kESk=
+github.com/seventv/common v0.0.0-20230107175235-62dbd2e54c8e h1:8xWDsQCuh3nsTOzBHHt9o973xgIfZhrhIqFuVQdokBI=
+github.com/seventv/common v0.0.0-20230107175235-62dbd2e54c8e/go.mod h1:jHHFe3uNMyzb/ReDqMvaI/A1euvV/PW/G+2PhcWQqWw=
 github.com/spf13/afero v1.9.3 h1:41FoI0fD7OR7mGcKE/aOiLkGreyf8ifIOQmJANWogMk=
 github.com/spf13/afero v1.9.3/go.mod h1:iUV7ddyEEZPO5gA3zD4fJt6iStLlL+Lg4m2cihcDf8Y=
 github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=

--- a/internal/app/connection/eventstream/eventstream_read.go
+++ b/internal/app/connection/eventstream/eventstream_read.go
@@ -57,7 +57,7 @@ func (es *EventStream) Read(gctx global.Context) {
 			}
 
 		case msg := <-dispatch:
-			_ = es.handler.OnDispatch(msg)
+			_ = es.handler.OnDispatch(gctx, msg)
 
 		// Listen for acks (i.e in response to a session mutation)
 		case msg := <-ack:

--- a/internal/app/connection/websocket/websocket_read.go
+++ b/internal/app/connection/websocket/websocket_read.go
@@ -101,7 +101,7 @@ func (w *WebSocket) Read(gctx global.Context) {
 			}
 		// Listen for incoming dispatches
 		case msg := <-dispatch:
-			_ = w.handler.OnDispatch(msg)
+			_ = w.handler.OnDispatch(gctx, msg)
 		}
 	}
 }


### PR DESCRIPTION
Adding or removing subscriptions, or expiring dedupe cache hashes, as part of a dispatch. This allows the API to systematically join subscriptions for an EventAPI connection, which is useful for cases where data needs followup