### PR TITLE
fix sse/eventstream since net.http refactor

### DIFF
--- a/internal/app/connection/connection.go
+++ b/internal/app/connection/connection.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"net/http"
 	"sync"
 	"time"
 
@@ -50,7 +51,7 @@ type Connection interface {
 	// Close sends a close frame with the specified code and ends the connection
 	SendClose(code events.CloseCode, after time.Duration)
 	// SetWriter defines the connection's writable stream (SSE only)
-	SetWriter(w *bufio.Writer)
+	SetWriter(w *bufio.Writer, f http.Flusher)
 }
 
 func IsClientSentOp(op events.Opcode) bool {

--- a/internal/app/connection/eventstream/eventstream.go
+++ b/internal/app/connection/eventstream/eventstream.go
@@ -23,6 +23,7 @@ import (
 
 type EventStream struct {
 	r                 *http.Request
+	f                 http.Flusher
 	ctx               context.Context
 	gctx              global.Context
 	cancel            context.CancelFunc
@@ -197,17 +198,21 @@ func (es *EventStream) Write(msg events.Message[json.RawMessage]) error {
 	if _, err = es.writer.Write(utils.S2B(sb.String())); err != nil {
 		zap.S().Errorw("failed to write to event stream connection", "error", err)
 	}
+
 	if err = es.writer.Flush(); err != nil {
 		return err
 	}
+
+	es.f.Flush()
 
 	es.seq++
 	return nil
 }
 
 // SetWriter implements Connection
-func (es *EventStream) SetWriter(w *bufio.Writer) {
+func (es *EventStream) SetWriter(w *bufio.Writer, f http.Flusher) {
 	es.writer = w
+	es.f = f
 }
 
 // Ready implements client.Connection

--- a/internal/app/connection/eventstream/eventstream_read.go
+++ b/internal/app/connection/eventstream/eventstream_read.go
@@ -2,11 +2,7 @@ package eventstream
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
-	"net"
-	"syscall"
 	"time"
 
 	"github.com/seventv/api/data/events"
@@ -63,17 +59,5 @@ func (es *EventStream) Read(gctx global.Context) {
 			// Dispatch the event to the client
 			es.handler.OnDispatch(gctx, msg)
 		}
-	}
-}
-
-func isNetConnClosedErr(err error) bool {
-	switch {
-	case
-		errors.Is(err, net.ErrClosed),
-		errors.Is(err, io.EOF),
-		errors.Is(err, syscall.EPIPE):
-		return true
-	default:
-		return false
 	}
 }

--- a/internal/app/connection/websocket/websocket.go
+++ b/internal/app/connection/websocket/websocket.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"net/http"
 	"sync"
 	"time"
 
@@ -199,7 +200,7 @@ func (w *WebSocket) OnClose() <-chan struct{} {
 	return w.ctx.Done()
 }
 
-func (*WebSocket) SetWriter(w *bufio.Writer) {
+func (*WebSocket) SetWriter(w *bufio.Writer, f http.Flusher) {
 	zap.S().Fatalw("called SetWriter() on a WebSocket connection")
 }
 

--- a/terraform/deployment.tf
+++ b/terraform/deployment.tf
@@ -130,7 +130,7 @@ resource "kubernetes_deployment" "app" {
             }
             limits = {
               cpu    = local.infra.production ? "0.5" : "150m"
-              memory = local.infra.production ? "1Gi" : "500Mi"
+              memory = local.infra.production ? "1.5Gi" : "500Mi"
             }
           }
 
@@ -289,7 +289,7 @@ resource "kubernetes_horizontal_pod_autoscaler_v2" "app" {
     }
 
     min_replicas = local.infra.production ? 4 : 1
-    max_replicas = 100
+    max_replicas = 200
 
     metric {
       type = "Pods"


### PR DESCRIPTION
This fixes the issue of the SSE/EventStream being unresponsive after refactoring away from fasthttp